### PR TITLE
#ifdef CRUX macros removed. Percolator no longer produces output for …

### DIFF
--- a/src/Caller.cpp
+++ b/src/Caller.cpp
@@ -1101,9 +1101,6 @@ void Caller::calcAndOutputResult(Scores& allScores, XMLInterface& xmlInterface){
   // calculate psms level probabilities TDA or TDC
   bool isUniquePeptideRun = false;
   calculatePSMProb(allScores, isUniquePeptideRun);
-#ifdef CRUX
-  processPsmScores(allScores);
-#endif
 
   if (xmlInterface.getXmlOutputFN().size() > 0){
     xmlInterface.writeXML_PSMs(allScores);
@@ -1115,9 +1112,7 @@ if (xmlInterface.getxmlPepOutputFN().size() > 0){
   if (reportUniquePeptides_ || ProteinProbEstimator::getCalcProteinLevelProb()){
     isUniquePeptideRun = true;
     calculatePSMProb(allScores, isUniquePeptideRun);
-#ifdef CRUX
-    processPeptideScores(allScores);
-#endif
+
     if (xmlInterface.getXmlOutputFN().size() > 0){
       xmlInterface.writeXML_Peptides(allScores);
     }
@@ -1126,9 +1121,7 @@ if (xmlInterface.getxmlPepOutputFN().size() > 0){
   // calculate protein level probabilities with Fido or Picked-protein
   if (ProteinProbEstimator::getCalcProteinLevelProb()) {
     calculateProteinProbabilities(allScores);
-#ifdef CRUX
-    processProteinScores(protEstimator_);
-#endif
+
     if (xmlInterface.getXmlOutputFN().size() > 0) {
       xmlInterface.writeXML_Proteins(protEstimator_);
     }

--- a/src/Caller.h
+++ b/src/Caller.h
@@ -123,13 +123,6 @@ class Caller {
   void calculateProteinProbabilities(Scores& allScores);
   void checkIsWritable(const std::string& filePath);
   
-#ifdef CRUX
-  virtual void processPsmScores(Scores& allScores) {}
-  virtual void processPeptideScores(Scores& allScores) {}
-  virtual void processProteinScores(ProteinProbEstimator* protEstimator) {}
-#endif
-
-
 };
 
 

--- a/src/Scores.cpp
+++ b/src/Scores.cpp
@@ -41,10 +41,6 @@ using namespace boost::algorithm;
 #include "ssl.h"
 #include "MassHandler.h"
 
-#ifdef CRUX
-#include "app/PercolatorAdapter.h"
-#endif
-
 inline bool operator>(const ScoreHolder& one, const ScoreHolder& other) {
   return (one.score > other.score) 
       || (one.score == other.score && one.pPSM->scan > other.pPSM->scan) 
@@ -302,7 +298,6 @@ void Scores::scoreAndAddPSM(ScoreHolder& sh,
 }
 
 void Scores::print(int label, std::ostream& os) {
-#ifndef CRUX
   std::vector<ScoreHolder>::iterator scoreIt = scores_.begin();
   os << "PSMId\t";
   if(PSMDescription::hasSpectrumFileName()) {
@@ -317,9 +312,6 @@ void Scores::print(int label, std::ostream& os) {
       os << rh << std::endl;
     }
   }
-#else
-  PercolatorAdapter::printScores(this, label, os);
-#endif
 }
 
 void Scores::populateWithPSMs(SetHandler& setHandler) {


### PR DESCRIPTION
…… (#340)

* #ifdef CRUX macros removed. Percolator no longer produces dedicated output for CRUX.